### PR TITLE
Use ansimarkup instead of colorama for color support.

### DIFF
--- a/nbcommands/__version__.py
+++ b/nbcommands/__version__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-VERSION = (0, 3, 2)
+VERSION = (0, 3, 3)
 PRERELEASE = None  # alpha, beta or rc
 REVISION = None
 

--- a/nbcommands/_cat.py
+++ b/nbcommands/_cat.py
@@ -19,8 +19,8 @@ def cat(ctx, *args, **kwargs):
     # Source: https://github.com/jbn/nbmerge
     merged, metadata = None, []
 
-    for file in kwargs["file"]:
-        with open(file, "r") as f:
+    for fin in kwargs["file"]:
+        with open(fin, "r") as f:
             nb = nbformat.read(f, as_version=4)
 
         metadata.append(nb.metadata)
@@ -35,7 +35,7 @@ def cat(ctx, *args, **kwargs):
         merged_metadata.update(meta)
     merged.metadata = merged_metadata
 
-    if kwargs["output"] is not None:
+    if kwargs["output"]:
         with open(kwargs["output"], "w") as f:
             nbformat.write(merged, f, version=4)
     else:

--- a/nbcommands/_grep.py
+++ b/nbcommands/_grep.py
@@ -2,31 +2,11 @@
 
 import re
 
+from ansimarkup import parse as ansi
 import click
 import nbformat
-from colorama import Fore, Style
 
 from . import __version__
-
-
-def color(s, c, style="bright"):
-    color_map = {
-        "black": Fore.BLACK,
-        "red": Fore.RED,
-        "green": Fore.GREEN,
-        "yellow": Fore.YELLOW,
-        "blue": Fore.BLUE,
-        "magenta": Fore.MAGENTA,
-        "cyan": Fore.CYAN,
-        "white": Fore.WHITE,
-    }
-    style_map = {
-        "dim": Style.DIM,
-        "normal": Style.NORMAL,
-        "bright": Style.BRIGHT,
-    }
-
-    return color_map[c] + style_map[style] + s + Style.RESET_ALL
 
 
 @click.command(name="nbgrep")
@@ -38,8 +18,8 @@ def grep(ctx, *args, **kwargs):
     """Search for a pattern in Jupyter notebooks."""
     pattern = kwargs["pattern"]
 
-    for file in kwargs["file"]:
-        with open(file, "r") as f:
+    for fin in kwargs["file"]:
+        with open(fin, "r") as f:
             nb = nbformat.read(f, as_version=4)
 
         for cell_n, cell in enumerate(nb.cells):
@@ -47,13 +27,13 @@ def grep(ctx, *args, **kwargs):
                 search = re.search(pattern, line)
                 if search is not None:
                     first, last = search.span()
-                    match = color(line[first:last], "red")
+                    match = ansi(f"<red>{line[first:last]}</red>")
                     click.echo(
-                        color(":", "cyan").join(
+                        ansi("<cyan>:</cyan>").join(
                             [
-                                color(file, "white", style="normal"),
-                                color("cell {}".format(cell_n + 1), "green"),
-                                color("line {}".format(line_n + 1), "green"),
+                                ansi(f"<white>{fin}</white>"),
+                                ansi(f"<green>cell {cell_n+1}</green>"),
+                                ansi(f"<green>line {line_n+1}</green>"),
                                 line.replace(pattern, match),
                             ]
                         )

--- a/nbcommands/terminal.py
+++ b/nbcommands/terminal.py
@@ -19,7 +19,6 @@ def display(cells):
         code = highlight(
             cell.source, LEXER_MAP[cell.cell_type], TerminalTrueColorFormatter()
         )
-        output.append(prompt)
-        output.append(code)
+        output.append(prompt + code)
 
     return output

--- a/nbcommands/terminal.py
+++ b/nbcommands/terminal.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from colorama import Fore, Style
+from ansimarkup import parse as ansi
 
 from pygments import highlight
 from pygments.lexers import PythonLexer
+from pygments.lexers.markup import MarkdownLexer
 from pygments.formatters import TerminalTrueColorFormatter
 
 
@@ -11,16 +12,12 @@ def display(cells):
     output = []
 
     for cell in cells:
-        execution_count = (
-            cell["execution_count"] if cell["execution_count"] is not None else " "
-        )
-        prompt = (
-            Fore.GREEN
-            + Style.BRIGHT
-            + "In [{}]: ".format(execution_count)
-            + Style.RESET_ALL
-        )
-        code = highlight(cell.source, PythonLexer(), TerminalTrueColorFormatter())
+        execution_count = cell.get("execution_count") or " "
+        prompt = ansi(f"<green>In [{execution_count}]</green>: ")
+        if cell.cell_type == "markdown":
+            code = highlight(cell.source, MarkdownLexer(), TerminalTrueColorFormatter())
+        else:
+            code = highlight(cell.source, PythonLexer(), TerminalTrueColorFormatter())
         output.append(prompt + code)
 
     return output

--- a/nbcommands/terminal.py
+++ b/nbcommands/terminal.py
@@ -7,6 +7,8 @@ from pygments.lexers import PythonLexer
 from pygments.lexers.markup import MarkdownLexer
 from pygments.formatters import TerminalTrueColorFormatter
 
+LEXER_MAP = {"markdown": MarkdownLexer(), "code": PythonLexer()}
+
 
 def display(cells):
     output = []
@@ -14,10 +16,10 @@ def display(cells):
     for cell in cells:
         execution_count = cell.get("execution_count") or " "
         prompt = ansi(f"<green>In [{execution_count}]</green>: ")
-        if cell.cell_type == "markdown":
-            code = highlight(cell.source, MarkdownLexer(), TerminalTrueColorFormatter())
-        else:
-            code = highlight(cell.source, PythonLexer(), TerminalTrueColorFormatter())
-        output.append(prompt + code)
+        code = highlight(
+            cell.source, LEXER_MAP[cell.cell_type], TerminalTrueColorFormatter()
+        )
+        output.append(prompt)
+        output.append(code)
 
     return output

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open("README.md", "r") as f:
 requires = [
     "black==19.10b0",
     "Click==7.0",
-    "colorama==0.4.1",
+    "ansimarkup==1.4.0",
     "nbformat==4.4.0",
     "Pygments==2.4.2",
 ]


### PR DESCRIPTION
Use the parse function from the ansimarkup package to render colored 
output instead of concatenating escape sequences from the colorama 
package.

En passant, also used the MarkdownLexer to highlight markdown cells.