### PR TITLE
Fix bug when execution_count = 0

### DIFF
--- a/nbcommands/terminal.py
+++ b/nbcommands/terminal.py
@@ -11,9 +11,10 @@ def display(cells):
     output = []
 
     for cell in cells:
-        execution_count = (
-            cell["execution_count"] if cell["execution_count"] is not None else " "
-        )
+        try:
+            execution_count = cell["execution_count"]
+        except KeyError:
+            execution_count = " "
         prompt = (
             Fore.GREEN
             + Style.BRIGHT


### PR DESCRIPTION
When execution_count does not exist, the commands nbcat, nbtail or nbhead throw an error. So far this has fixed it for me and now those commands work again.

Related issue: #19 