### PR TITLE
[MRG] Note what nbtouch does for nonexistent files

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,8 @@ nbcommands installs the following commands which let you interact with your Jupy
 nbtouch
 ^^^^^^^
 
-Update the access and modification times of each Jupyter notebook to the current time::
+Update the access and modification times of each Jupyter notebook to the current time,
+or create empty notebook files where none exist::
 
     $ nbtouch notebook1.ipynb notebook2.ipynb
 

--- a/nbcommands/_touch.py
+++ b/nbcommands/_touch.py
@@ -14,7 +14,10 @@ from . import __version__
 @click.argument("file", nargs=-1)
 @click.pass_context
 def touch(ctx, *args, **kwargs):
-    """Update the access and modification times of each Jupyter notebook to the current time."""
+    """Update the access and modification times of each Jupyter notebook to the current time.
+
+    If FILE does not exist, it will be created as an empty notebook.
+    """
     for file in kwargs["file"]:
         if not os.path.exists(file):
             nb = nbformat.v4.new_notebook()


### PR DESCRIPTION
Looking at the docs, I was confused why `nbtouch` would exist when `touch` works exactly the same for existing notebook files, but on looking at the code I saw that it creates empty *notebook* files, which is useful! This behavior wasn't documented as far as I could tell, so I added a mention of it to the nbtouch docstring and summary in the docs.