### PR TITLE
support directories in nbgrep

### DIFF
--- a/nbcommands/_grep.py
+++ b/nbcommands/_grep.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pathlib
 import re
 
 import click
@@ -32,14 +33,29 @@ def color(s, c, style="bright"):
 @click.command(name="nbgrep")
 @click.version_option(version=__version__)
 @click.argument("pattern")
-@click.argument("file", nargs=-1)
+@click.argument("file", nargs=-1, type=click.Path(exists=True), required=True)
 @click.pass_context
 def grep(ctx, *args, **kwargs):
     """Search for a pattern in Jupyter notebooks."""
     pattern = kwargs["pattern"]
+    
+    def collect_files():
+        """generator for paths
+        
+        FILE can be individual files or directories.
+        If it's a directory, find all .ipynb files in the directory.
+        """
+        for path in kwargs["file"]:
+            path = pathlib.Path(path)
+            if path.is_dir():
+                for filename in path.glob("**/*.ipynb"):
+                    yield filename
+            else:
+                yield path
 
-    for file in kwargs["file"]:
-        with open(file, "r") as f:
+    for file in collect_files():
+        filename = str(file)
+        with file.open("r") as f:
             nb = nbformat.read(f, as_version=4)
 
         for cell_n, cell in enumerate(nb.cells):
@@ -51,7 +67,7 @@ def grep(ctx, *args, **kwargs):
                     click.echo(
                         color(":", "cyan").join(
                             [
-                                color(file, "white", style="normal"),
+                                color(filename, "white", style="normal"),
                                 color("cell {}".format(cell_n + 1), "green"),
                                 color("line {}".format(line_n + 1), "green"),
                                 line.replace(pattern, match),


### PR DESCRIPTION
- when a directory is given, grep all notebooks in the directory
- set type to Path to get errors from click when paths don't exist
- set required=True for "missing argument" error when no path is specified, instead of doing nothing